### PR TITLE
Refactor `src/key.rs`.

### DIFF
--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -43,6 +43,7 @@ use std::io::{IoError, IoResult};
 use std::rand::OsRng;
 use libc::c_int;
 use sync::one::{Once, ONCE_INIT};
+use key::PublicKeyTrait;
 
 pub mod constants;
 pub mod ffi;


### PR DESCRIPTION
Key points are:

* Avoid copying in `from_slice()`
* Generalize Compressed/Uncompressed Public Key over both:
  * enum
  * trait