### PR TITLE
Fix Compilation Error

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,25 +16,25 @@
 //! Constants
 
 /// The size (in bytes) of a nonce
-pub static NONCE_SIZE: uint = 32;
+pub const NONCE_SIZE: uint = 32;
 
 /// The size (in bytes) of a secret key
-pub static SECRET_KEY_SIZE: uint = 32;
+pub const SECRET_KEY_SIZE: uint = 32;
 
 /// The size (in bytes) of an uncompressed public key
-pub static UNCOMPRESSED_PUBLIC_KEY_SIZE: uint = 65;
+pub const UNCOMPRESSED_PUBLIC_KEY_SIZE: uint = 65;
 
 /// The size (in bytes) of a compressed public key
-pub static COMPRESSED_PUBLIC_KEY_SIZE: uint = 33;
+pub const COMPRESSED_PUBLIC_KEY_SIZE: uint = 33;
 
 /// The maximum size of a signature
-pub static MAX_SIGNATURE_SIZE: uint = 72;
+pub const MAX_SIGNATURE_SIZE: uint = 72;
 
 /// The maximum size of a compact signature
-pub static MAX_COMPACT_SIGNATURE_SIZE: uint = 64;
+pub const MAX_COMPACT_SIGNATURE_SIZE: uint = 64;
 
 /// The order of the secp256k1 curve
-pub static CURVE_ORDER: [u8, ..32] = [
+pub const CURVE_ORDER: [u8, ..32] = [
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
     0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b,
@@ -42,7 +42,7 @@ pub static CURVE_ORDER: [u8, ..32] = [
 ];
 
 /// The X coordinate of the generator
-pub static GENERATOR_X: [u8, ..32] = [
+pub const GENERATOR_X: [u8, ..32] = [
     0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac,
     0x55, 0xa0, 0x62, 0x95, 0xce, 0x87, 0x0b, 0x07,
     0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9,
@@ -50,7 +50,7 @@ pub static GENERATOR_X: [u8, ..32] = [
 ];
 
 /// The Y coordinate of the generator
-pub static GENERATOR_Y: [u8, ..32] = [
+pub const GENERATOR_Y: [u8, ..32] = [
     0x48, 0x3a, 0xda, 0x77, 0x26, 0xa3, 0xc4, 0x65,
     0x5d, 0xa4, 0xfb, 0xfc, 0x0e, 0x11, 0x08, 0xa8,
     0xfd, 0x17, 0xb4, 0x48, 0xa6, 0x85, 0x54, 0x19,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,11 +14,11 @@
 //
 
 //! FFI bindings
-use libc::{c_int, c_uchar};
+use libc::{c_int, c_uchar, c_uint};
 
 #[link(name = "secp256k1")]
 extern "C" {
-    pub fn secp256k1_start();
+    pub fn secp256k1_start(flags:c_uint);
 
     pub fn secp256k1_stop();
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -99,7 +99,7 @@ impl Nonce {
     #[inline]
     #[allow(non_snake_case)] // so we can match the names in the RFC
     pub fn deterministic(msg: &[u8], key: &SecretKey) -> Nonce {
-        static HMAC_SIZE: uint = 64;
+        const HMAC_SIZE: uint = 64;
 
         macro_rules! hmac(
             ($res:expr <- key $key:expr, data $($data:expr),+) => ({

--- a/src/key.rs
+++ b/src/key.rs
@@ -252,7 +252,7 @@ impl PublicKey {
                 pk.as_mut_ptr(), &mut len,
                 sk.as_ptr(), compressed), 1);
         }
-        assert_eq!(len as uint, pk.len()); 
+        assert_eq!(len as uint, pk.len());
         pk
     }
 

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -30,11 +30,11 @@
 #![feature(globs)]  // for tests only
 
 // Coding conventions
-#![deny(non_uppercase_statics)]
+#![deny(non_upper_case_globals)]
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![warn(missing_doc)]
+#![warn(missing_docs)]
 
 extern crate "rust-crypto" as crypto;
 

--- a/src/secp256k1.rs
+++ b/src/secp256k1.rs
@@ -46,7 +46,7 @@ extern crate test;
 use std::intrinsics::copy_nonoverlapping_memory;
 use std::io::IoResult;
 use std::rand::{OsRng, Rng, SeedableRng};
-use libc::c_int;
+use libc::{c_int, c_uint};
 use sync::one::{Once, ONCE_INIT};
 
 use crypto::fortuna::Fortuna;
@@ -64,6 +64,8 @@ pub struct RecoveryId(i32);
 
 /// An ECDSA signature
 pub struct Signature(uint, [u8, ..constants::MAX_SIGNATURE_SIZE]);
+
+const SECP256K1_START_SIGN_AND_START_VERIFY:c_uint = 3;
 
 impl Signature {
     /// Converts the signature to a raw pointer suitable for use
@@ -148,7 +150,7 @@ pub struct Secp256k1 {
 pub fn init() {
     unsafe {
         Secp256k1_init.doit(|| {
-            ffi::secp256k1_start();
+            ffi::secp256k1_start(SECP256K1_START_SIGN_AND_START_VERIFY);
         });
     }
 }


### PR DESCRIPTION
When I was trying to build https://github.com/apoelstra/rust-bitcoin, I kept getting the following error messages:
```
src/key.rs:85:13: 85:34 error: static variables cannot be referenced in a pattern, use a `const` instead
src/key.rs:85             constants::NONCE_SIZE => {
                          ^~~~~~~~~~~~~~~~~~~~~
src/key.rs:176:13: 176:39 error: static variables cannot be referenced in a pattern, use a `const` instead
src/key.rs:176             constants::SECRET_KEY_SIZE => {
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/key.rs:263:13: 263:50 error: static variables cannot be referenced in a pattern, use a `const` instead
src/key.rs:263             constants::COMPRESSED_PUBLIC_KEY_SIZE => {
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/key.rs:276:13: 276:52 error: static variables cannot be referenced in a pattern, use a `const` instead
src/key.rs:276             constants::UNCOMPRESSED_PUBLIC_KEY_SIZE => {
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 4 previous errors
```
and then (after forking and fixing) 
```
src/key.rs:116:27: 116:36 error: expected constant integer for repeat count, found variable
src/key.rs:116         let mut x = [0, ..HMAC_SIZE];
                                         ^~~~~~~~~
src/key.rs:121:32: 121:41 error: expected constant integer for repeat count, found variable
src/key.rs:121         let mut V = [0x01u8, ..HMAC_SIZE];
                                              ^~~~~~~~~
src/key.rs:123:32: 123:41 error: expected constant integer for repeat count, found variable
src/key.rs:123         let mut K = [0x00u8, ..HMAC_SIZE];
                                              ^~~~~~~~~
src/key.rs:141:36: 141:45 error: expected constant integer for repeat count, found variable
src/key.rs:141             let mut T = [0x00u8, ..HMAC_SIZE];
                                                  ^~~~~~~~~
error: aborting due to 4 previous errors
```
Additionally, the C API [changed last month](https://github.com/bitcoin/secp256k1/commit/04e34d18c37e0cbcea8094c299c27af240237b8b) which was causing a nasty error when deriving public keys. 

I'm an extreme Rust n00b, so please let me know if anything could be done in a cleaner and more idiomatic way.